### PR TITLE
Fix output apk path

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,7 @@ platform :android do
 
     APK_LOCATION = "#{lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]}"
     sh("mv", "#{APK_LOCATION}", ENV["OUTPUT_PATH"])
-    sh("mv", ENV["OUTPUT_PATH"], "../")
+    sh("cp", ENV["OUTPUT_PATH"], "../")
 
     if ENV["BROWSERSTACK_UPLOAD"] == 'true'
       upload_to_browserstack_app_live(


### PR DESCRIPTION
The APK was moved in the parent folder of the `output-path`