### PR TITLE
feat: add inputs for `release-track` and `release-status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Bundler version to be used.
 
 Specify the env that fastlane should load.
 
+### `release-track`
+
+Release track to target. Default `"internal"`.
+
+### `release-status`
+
+Status of the uploaded release. Default `"draft"`.
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,14 @@ inputs:
     description: "Specify the bundler version you wish to use"
     default: "2.3"
     required: false
+  release-track:
+    description: "Release track to target"
+    default: "internal"
+    required: false
+  release-status:
+    description: "Status of the release"
+    default: "draft"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -96,6 +104,8 @@ runs:
         BROWSERSTACK_USERNAME: ${{ inputs.browserstack-username }}
         BROWSERSTACK_ACCESS_KEY: ${{ inputs.browserstack-access-key }}
         FASTLANE_ENV: ${{ inputs.fastlane-env }}
+        RELEASE_TRACK: ${{ inputs.release-track }}
+        RELEASE_STATUS: ${{ inputs.release-status }}
         ACTION_PATH: ${{ github.action_path }}
       run: . ${{ github.action_path }}/build.sh
       shell: sh

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,8 +28,8 @@ platform :android do
       upload_to_play_store(
         apk: ENV["OUTPUT_PATH"],
         package_name: ENV["ANDROID_PACKAGE_NAME"],
-        release_status: "draft",
-        track: "internal",
+        release_status: ENV["RELEASE_STATUS"],
+        track: ENV["RELEASE_TRACK"],
         json_key_data: ENV["PLAY_STORE_JSON_KEY_DATA"],
       )
     end
@@ -40,7 +40,7 @@ platform :android do
     if ENV['INCREMENT_BUILD_NUMBER'] == 'true'
       previous_build_number = google_play_track_version_codes(
         package_name: ENV["PACKAGE_NAME"],
-        track: "internal",
+        track: ENV["RELEASE_TRACK"],
         json_key_data: ENV["PLAY_STORE_JSON_KEY_DATA"],
       )[0]
 
@@ -82,8 +82,8 @@ platform :android do
       upload_to_play_store(
         aab: ENV["OUTPUT_PATH"],
         package_name: ENV["PACKAGE_NAME"],
-        release_status: "draft",
-        track: "internal",
+        release_status: ENV["RELEASE_STATUS"],
+        track: ENV["RELEASE_TRACK"],
         json_key_data: ENV["PLAY_STORE_JSON_KEY_DATA"],
       )
     end


### PR DESCRIPTION
Add support for targetting release tracks other than `internal` and release status' other than `draft`